### PR TITLE
Environment info removed, location path changed

### DIFF
--- a/lab/integration-testing/FileCounter/hu.bme.mit.filecounter.sut/filecounter.target
+++ b/lab/integration-testing/FileCounter/hu.bme.mit.filecounter.sut/filecounter.target
@@ -2,6 +2,6 @@
 <?pde version="3.8"?><target name="FileCounter Platform" sequenceNumber="16">
 <locations>
 <location path="${eclipse_home}" type="Profile"/>
-<location path="${workspace_loc}/hu.bme.mit.filecounter.sut/dist" type="Directory"/>
+<location path="${project_loc}/dist" type="Directory"/>
 </locations>
 </target>

--- a/lab/integration-testing/FileCounter/hu.bme.mit.filecounter.sut/filecounter.target
+++ b/lab/integration-testing/FileCounter/hu.bme.mit.filecounter.sut/filecounter.target
@@ -4,10 +4,4 @@
 <location path="${eclipse_home}" type="Profile"/>
 <location path="${workspace_loc}/hu.bme.mit.filecounter.sut/dist" type="Directory"/>
 </locations>
-<environment>
-<os>linux</os>
-<ws>gtk</ws>
-<arch>x86</arch>
-<nl>en_US</nl>
-</environment>
 </target>


### PR DESCRIPTION
The hardwired environmental information caused faults on non-linux (and/or non-32 bit?) systems. (But it works this way)
The project can only be found in the workspace, if the user chooses to copy it from the git folder. Using `${project_loc}` is way more straightforward than tampering with workspace paths.
